### PR TITLE
UI Bug: Game Instructions Text Cut Off or Misaligned on TIC-TAC-TOE Interface 

### DIFF
--- a/src/app/game/tic-tac-toe/single-player/page.module.css
+++ b/src/app/game/tic-tac-toe/single-player/page.module.css
@@ -10,6 +10,7 @@
 .selectSymbolContainer > h2 {
     color: var(--black);
 }
+
 .symbolContainer{
 
 }

--- a/src/components/gameBoard.module.css
+++ b/src/components/gameBoard.module.css
@@ -1,5 +1,5 @@
 .boardContainer{
-    width: 100vw;
+    width: 100%;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -81,13 +81,15 @@
 .resetButtonContainer{
     position: absolute;
     backdrop-filter: blur(1.5px);
-    width: 100vw;
+    width: 100%;
+    max-width: 100%;
     height: 70vh;
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
 }
+
 .resetButton{
     background-color: var(--light-yellow);
     font-size: 16px;
@@ -185,4 +187,27 @@
 
 .youtubeLink:hover {
     background-color: var(--light-yellow);
+}
+
+
+/* Reponsive Typography  */
+
+@media (min-width: 768px) {
+    .boardContainer > h1,
+    .turnStatus {
+        font-size: 24px;
+    }
+
+    .gridButton {
+        font-size: 2rem;
+    }
+
+    .workingContainer {
+        padding: 0 2rem;
+    }
+
+    .workingContainer h2,
+    .workingContainer h3 {
+        font-size: 1.5rem;
+    }
 }


### PR DESCRIPTION
### **Description**
<hr/>

**The issue was related to layout overflow in the GameBoard component, where using width: 100vw caused text and UI elements to get cut off on larger screens due to ignoring scrollbar width.**


### **Attachments**
<hr/>

<img width="1072" height="1280" alt="image" src="https://github.com/user-attachments/assets/b222b52c-cd87-4b75-922d-7fd554400ae9" />

<hr/>

_**Fixed layout overflow issue in the GameBoard by replacing width: 100vw with 100%, which was causing text cutoff**_

_**Also added responsive typography to improve text readability across screen sizes by adjusting font sizes of headings and buttons using media queries.**_

Resolves : #18 
