### PR TITLE
Update Sudoku link to use relative path in Footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -36,7 +36,8 @@ export default function Footer() {
                     <div className={styles["footer-right-link-container"]} >
                         <p>Play Game</p>
                         <Link href={"https://oldschoolgame.vercel.app/game/tic-tac-toe/single-player"}>Tic Tac Toe</Link>
-                        <Link href={"http://localhost:3000/game/sudoku"}>Sudoku</Link>
+                        <Link href={"/game/sudoku"}>Sudoku</Link> 
+                        {/* The link above in local instead it should be relative  */}
                         <Link href={"https://ukculture.netlify.app/contact"}>Contact us</Link>
                     </div>
                     <div className={styles["footer-right-link-container"]} >


### PR DESCRIPTION
Hi @ajaynegi45 
I've been troubleshooting an issue reported in the repo (https://github.com/ajaynegi45/Old-School-Game) where footer links in the deployed Vercel app (https://oldschoolgame.vercel.app/) aren't working, while they function fine locally. The main problem is with the Sudoku link in the Footer component (src/components/Footer.tsx or similar), which is hardcoded to http://localhost:3000/game/sudoku. This resolves locally but fails on Vercel since it points to a non-existent local server in production.
I have applied the fix using :
<Link href="/game/sudoku">Sudoku</Link>
This should resolve to https://oldschoolgame.vercel.app/game/sudoku on deployment.
The link works locally , kindly redeploy the app and update the vercel link in the about of the repo(if needed).

Resolves #20 